### PR TITLE
Remove colons in 'order' parameter passed to concat::fragment

### DIFF
--- a/manifests/domain_realm.pp
+++ b/manifests/domain_realm.pp
@@ -44,7 +44,7 @@ define mit_krb5::domain_realm(
     })
     concat::fragment { "mit_krb5::domain_realm::${title}":
       target  => $mit_krb5::krb5_conf_path,
-      order   => "21realm::${realm}::${title}",
+      order   => "21realm_${realm}_${title}",
       content => template('mit_krb5/domain_realm.erb'),
     }
   }

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -89,7 +89,7 @@ define mit_krb5::realm(
   })
   concat::fragment { "mit_krb5::realm::${title}":
     target  => $mit_krb5::krb5_conf_path,
-    order   => "11realm::${title}",
+    order   => "11realm_${title}",
     content => template('mit_krb5/realm.erb'),
   }
 }


### PR DESCRIPTION
Replace double-colons with underscores in the `order` param passed to `concat::fragment`. This is required to work with `puppetlabs/concat` v1.2.1 and greater.