### PR TITLE
Add support for canonicalize option present in mit_krb5 1.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ parameters are used to define contents of \[libdefaults\] section.
 - safe\_checksum\_type
 - preferred\_preauth\_types
 - ccache\_type
+- canonicalize (mit_krb5 1.11+ - RHEL6 has 1.10)
 - dns\_lookup\_kdc
 - dns\_lookup\_realm
 - dns\_fallback

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ parameters are used to define contents of \[libdefaults\] section.
 - safe\_checksum\_type
 - preferred\_preauth\_types
 - ccache\_type
-- canonicalize (mit_krb5 1.11+ - RHEL6 has 1.10)
+- canonicalize (mit_krb5 1.11+ - RHEL6/wheezy only have 1.10)
 - dns\_lookup\_kdc
 - dns\_lookup\_realm
 - dns\_fallback

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,12 @@
 #   default value for this setting is "17, 16, 15, 14", which forces libkrb5 to
 #   attempt to use PKINIT if it is supported.
 #
+# [*canonicalize*]
+#   If this flag is set to true, initial ticket requests to the KDC will
+#   request canonicalization of the client principal name, and answers with
+#   different client principals than the requested principal will be accepted.
+#   The default value is false.
+#
 # [*ccache_type*]
 #   User this parameter on systems which are DCE clients, to specify the type
 #   of cache to be created by kinit, or hen forwarded tickets are received. DCE
@@ -213,6 +219,7 @@ class mit_krb5(
   $safe_checksum_type       = '',
   $preferred_preauth_types  = '',
   $ccache_type              = '',
+  $canonicalize             = '',
   $dns_lookup_kdc           = '',
   $dns_lookup_realm         = '',
   $dns_fallback             = '',

--- a/templates/libdefaults.erb
+++ b/templates/libdefaults.erb
@@ -16,6 +16,7 @@
   'safe_checksum_type',
   'preferred_preauth_types',
   'ccache_type',
+  'canonicalize',
   'dns_lookup_kdc',
   'dns_lookup_realm',
   'dns_fallback',


### PR DESCRIPTION
All supported Ubuntu versions, RHEL7 and Debian Jessie all have support for this option in libdefaults.

Only RHEL6 and Debian Wheezy don't support it - added a comment in README.md to that effect.